### PR TITLE
Adjustments for wetterdienst 0.16

### DIFF
--- a/notebooks/fileio/wradlib_load_DWD_opendata_volumes.ipynb
+++ b/notebooks/fileio/wradlib_load_DWD_opendata_volumes.ipynb
@@ -41,6 +41,7 @@
    "source": [
     "import wradlib as wrl\n",
     "import warnings\n",
+    "from IPython import get_ipython\n",
     "warnings.filterwarnings('ignore')\n",
     "import matplotlib.pyplot as pl\n",
     "import numpy as np\n",
@@ -58,11 +59,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import urllib3\n",
-    "import os\n",
-    "import io\n",
-    "import glob\n",
-    "import shutil\n",
     "import datetime\n",
     "from itertools import chain"
    ]
@@ -83,8 +79,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from wetterdienst.dwd.radar import DWDRadarValues, DWDRadarParameter, DWDRadarDate, DWDRadarDataFormat, DWDRadarDataSubset\n",
-    "from wetterdienst.dwd.radar.sites import DWDRadarSite"
+    "from wetterdienst.provider.dwd.radar import DwdRadarDataFormat, DwdRadarDataSubset, DwdRadarParameter, DwdRadarValues\n",
+    "from wetterdienst.provider.dwd.radar.sites import DwdRadarSite"
    ]
   },
   {
@@ -96,22 +92,23 @@
     "start_date = datetime.datetime.utcnow()\n",
     "\n",
     "# Horizontal Doppler Velocity\n",
-    "request_velocity = DWDRadarValues(\n",
-    "    parameter=DWDRadarParameter.SWEEP_VOL_VELOCITY_H,\n",
+    "request_velocity = DwdRadarValues(\n",
+    "    parameter=DwdRadarParameter.SWEEP_VOL_VELOCITY_H,\n",
     "    start_date=start_date - datetime.timedelta(hours=2),\n",
     "    end_date=start_date,\n",
-    "    site=DWDRadarSite.ESS,\n",
-    "    fmt=DWDRadarDataFormat.HDF5,\n",
-    "    subset=DWDRadarDataSubset.POLARIMETRIC,\n",
+    "    site=DwdRadarSite.ESS,\n",
+    "    fmt=DwdRadarDataFormat.HDF5,\n",
+    "    subset=DwdRadarDataSubset.POLARIMETRIC,\n",
     ")\n",
     "\n",
     "# Horizontal Reflectivity\n",
-    "request_reflectivity = DWDRadarValues(\n",
-    "    parameter=DWDRadarParameter.SWEEP_VOL_REFLECTIVITY_H,\n",
+    "request_reflectivity = DwdRadarValues(\n",
+    "    parameter=DwdRadarParameter.SWEEP_VOL_REFLECTIVITY_H,\n",
     "    start_date=start_date - datetime.timedelta(hours=2),\n",
     "    end_date=start_date,\n",
-    "    site=DWDRadarSite.ESS,fmt=DWDRadarDataFormat.HDF5,\n",
-    "    subset=DWDRadarDataSubset.POLARIMETRIC,\n",
+    "    site=DwdRadarSite.ESS,\n",
+    "    fmt=DwdRadarDataFormat.HDF5,\n",
+    "    subset=DwdRadarDataSubset.POLARIMETRIC,\n",
     ")\n",
     "\n",
     "# Submit requests.\n",
@@ -476,7 +473,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.0"
+   "version": "3.9.2"
   }
  },
  "nbformat": 4,

--- a/notebooks/radolan/radolan_network.ipynb
+++ b/notebooks/radolan/radolan_network.ipynb
@@ -32,111 +32,33 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import datetime\n",
     "import wradlib as wrl\n",
     "import matplotlib.pyplot as pl\n",
     "import matplotlib as mpl\n",
     "import warnings\n",
+    "from IPython import get_ipython\n",
+    "from wetterdienst.provider.dwd.radar import DwdRadarParameter, DwdRadarValues\n",
+    "from wetterdienst.provider.dwd.radar.api import DwdRadarSites\n",
     "warnings.filterwarnings('ignore')\n",
     "try:\n",
     "    get_ipython().magic(\"matplotlib inline\")\n",
     "except:\n",
     "    pl.ion()\n",
     "import numpy as np\n",
-    "from osgeo import osr"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def get_radar_locations():\n",
-    "    radars = {}\n",
-    "    radar = {'name': 'ASR Dresden', 'wmo': 10487, 'lon': 13.76347,\n",
-    "             'lat': 51.12404, 'alt': 261}\n",
-    "    radars['ASD'] = radar\n",
+    "from osgeo import osr\n",
     "\n",
-    "    radar = {'name': 'Boostedt', 'wmo': 10132, 'lon': 10.04687,\n",
-    "             'lat': 54.00438, 'alt': 124.56}\n",
-    "    radars['BOO'] = radar\n",
+    "# load radolan data\n",
+    "start_date = datetime.datetime.utcnow()\n",
     "\n",
-    "    radar = {'name': 'Dresden', 'wmo': 10488, 'lon': 13.76865, 'lat': 51.12465,\n",
-    "             'alt': 263.36}\n",
-    "    radars['DRS'] = radar\n",
+    "radar_data = DwdRadarValues(\n",
+    "    parameter=DwdRadarParameter.RADOLAN_CDC.RW_REFLECTIVITY,\n",
+    "    start_date=start_date - datetime.timedelta(hours=2),\n",
+    "    end_date=start_date,\n",
+    ")\n",
     "\n",
-    "    radar = {'name': 'Eisberg', 'wmo': 10780, 'lon': 12.40278, 'lat': 49.54066,\n",
-    "             'alt': 798.79}\n",
-    "    radars['EIS'] = radar\n",
-    "\n",
-    "    radar = {'name': 'Emden', 'wmo': 10204, 'lon': 7.02377, 'lat': 53.33872,\n",
-    "             'alt': 58}\n",
-    "    radars['EMD'] = radar\n",
-    "\n",
-    "    radar = {'name': 'Essen', 'wmo': 10410, 'lon': 6.96712, 'lat': 51.40563,\n",
-    "             'alt': 185.10}\n",
-    "    radars['ESS'] = radar\n",
-    "\n",
-    "    radar = {'name': 'Feldberg', 'wmo': 10908, 'lon': 8.00361, 'lat': 47.87361,\n",
-    "             'alt': 1516.10}\n",
-    "    radars['FBG'] = radar\n",
-    "\n",
-    "    radar = {'name': 'Flechtdorf', 'wmo': 10440, 'lon': 8.802, 'lat': 51.3112,\n",
-    "             'alt': 627.88}\n",
-    "    radars['FLD'] = radar\n",
-    "\n",
-    "    radar = {'name': 'Hannover', 'wmo': 10339, 'lon': 9.69452, 'lat': 52.46008,\n",
-    "             'alt': 97.66}\n",
-    "    radars['HNR'] = radar\n",
-    "\n",
-    "    radar = {'name': 'Neuhaus', 'wmo': 10557, 'lon': 11.13504, 'lat': 50.50012,\n",
-    "             'alt': 878.04}\n",
-    "    radars['NEU'] = radar\n",
-    "\n",
-    "    radar = {'name': 'Neuheilenbach', 'wmo': 10605, 'lon': 6.54853,\n",
-    "             'lat': 50.10965, 'alt': 585.84}\n",
-    "    radars['NHB'] = radar\n",
-    "\n",
-    "    radar = {'name': 'Offenthal', 'wmo': 10629, 'lon': 8.71293, 'lat': 49.9847,\n",
-    "             'alt': 245.80}\n",
-    "    radars['OFT'] = radar\n",
-    "\n",
-    "    radar = {'name': 'Proetzel', 'wmo': 10392, 'lon': 13.85821,\n",
-    "             'lat': 52.64867, 'alt': 193.92}\n",
-    "    radars['PRO'] = radar\n",
-    "\n",
-    "    radar = {'name': 'Memmingen', 'wmo': 10950, 'lon': 10.21924,\n",
-    "             'lat': 48.04214, 'alt': 724.40}\n",
-    "    radars['MEM'] = radar\n",
-    "\n",
-    "    radar = {'name': 'Rostock', 'wmo': 10169, 'lon': 12.05808, 'lat': 54.17566,\n",
-    "             'alt': 37}\n",
-    "    radars['ROS'] = radar\n",
-    "\n",
-    "    radar = {'name': 'Isen', 'wmo': 10873, 'lon': 12.10177, 'lat': 48.1747,\n",
-    "             'alt': 677.77}\n",
-    "    radars['ISN'] = radar\n",
-    "\n",
-    "    radar = {'name': 'Tuerkheim', 'wmo': 10832, 'lon': 9.78278,\n",
-    "             'lat': 48.58528, 'alt': 767.62}\n",
-    "    radars['TUR'] = radar\n",
-    "\n",
-    "    radar = {'name': 'Ummendorf', 'wmo': 10356, 'lon': 11.17609,\n",
-    "             'lat': 52.16009, 'alt': 183}\n",
-    "    radars['UMM'] = radar\n",
-    "\n",
-    "    return radars"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# load radolan file\n",
-    "rw_filename = wrl.util.get_wradlib_data_file('radolan/showcase/raa01-rw_10000-1408102050-dwd---bin.gz')\n",
-    "rwdata, rwattrs = wrl.io.read_radolan_composite(rw_filename)"
+    "results = radar_data.query()\n",
+    "rwdata, rwattrs = wrl.io.read_radolan_composite(next(results).data)"
    ]
   },
   {
@@ -200,7 +122,7 @@
    "outputs": [],
    "source": [
     "# get radar dict\n",
-    "radars = get_radar_locations()"
+    "radars = DwdRadarSites()"
    ]
   },
   {
@@ -210,8 +132,8 @@
    "outputs": [],
    "source": [
     "def plot_radar(radar, ax, proj):\n",
-    "    \n",
-    "    site = (radar['lon'], radar['lat'], radar['alt'] )\n",
+    "\n",
+    "    site = (radar['longitude'], radar['latitude'], radar['heightantenna'] )\n",
     "    \n",
     "    # build polygons for maxrange rangering\n",
     "    polygons = wrl.georef.spherical_to_polyvert(r, az, 0,\n",
@@ -234,7 +156,7 @@
     "    \n",
     "    # plot radar location and information text\n",
     "    ax.plot(x_loc, y_loc, 'r+')\n",
-    "    ax.text(x_loc, y_loc, radar['name'], color='r')"
+    "    ax.text(x_loc, y_loc, radar['location'], color='r')"
    ]
   },
   {
@@ -258,10 +180,7 @@
     "pl.grid(color='r')\n",
     "for radar_id in rwattrs['radarlocations']:\n",
     "    # get radar coords etc from dict\n",
-    "    # repair Ummendorf ID\n",
-    "    if radar_id == 'umd':\n",
-    "        radar_id = 'umm'\n",
-    "    radar = radars[radar_id.upper()]\n",
+    "    radar = radars.by_odimcode(radar_id)\n",
     "    plot_radar(radar, ax1, proj_wgs)"
    ]
   },
@@ -285,10 +204,7 @@
     "pl.grid(color='r')\n",
     "for radar_id in rwattrs['radarlocations']:\n",
     "    # get radar coords etc from dict\n",
-    "    # repair Ummendorf ID\n",
-    "    if radar_id == 'umd':\n",
-    "        radar_id = 'umm'\n",
-    "    radar = radars[radar_id.upper()]\n",
+    "    radar = radars.by_odimcode(radar_id)\n",
     "    plot_radar(radar, ax2, proj_stereo)"
    ]
   }
@@ -310,7 +226,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.9.2"
   },
   "toc": {
    "colors": {


### PR DESCRIPTION
Dear Kai,

this patch accompanies the recent release of Wetterdienst 0.16. I hope you like it.

- Adjust Wetterdienst API within notebook "Load ODIM_H5 volume data".
- Use the new `DwdRadarSites()` API within "RADOLAN Radar Network" notebook.
   Wetterdienst now provides an improved list of radar sites curated by OPERA and a reasonable API on top.
   This resolves #49 and will reduce the amount of code including a handwritten station map.

With kind regards,
Andreas.

cc @gutzbenj
