### PR TITLE
FIX: dwd-grids

### DIFF
--- a/ci/requirements/notebooks.yml
+++ b/ci/requirements/notebooks.yml
@@ -16,6 +16,7 @@ dependencies:
   - h5netcdf
   - lat_lon_parser
   - nbconvert
+  - nc-time-axis
   - netCDF4
   - notebook
   - numpy

--- a/notebooks/fileio/wradlib_odim_backend.ipynb
+++ b/notebooks/fileio/wradlib_odim_backend.ipynb
@@ -476,7 +476,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/notebooks/fileio/wradlib_xarray_radial_odim.ipynb
+++ b/notebooks/fileio/wradlib_xarray_radial_odim.ipynb
@@ -45,7 +45,8 @@
     "    get_ipython().magic(\"matplotlib inline\")\n",
     "except:\n",
     "    pl.ion()\n",
-    "from wradlib.io.xarray_depr import CfRadial, OdimH5"
+    "from wradlib.io.xarray_depr import CfRadial, OdimH5\n",
+    "import tempfile"
    ]
   },
   {
@@ -313,8 +314,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cf1.to_odim('knmi_odim.h5')\n",
-    "cf1.to_cfradial2('knmi_odim_as_cfradial.nc')"
+    "h5_tempfile = tempfile.NamedTemporaryFile(suffix=\".h5\").name\n",
+    "nc_tempfile = tempfile.NamedTemporaryFile(suffix=\".nc\").name\n",
+    "cf1.to_odim(h5_tempfile)\n",
+    "cf1.to_cfradial2(nc_tempfile)"
    ]
   },
   {
@@ -330,8 +333,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cf1a = OdimH5('knmi_odim.h5', standard='cf', georef=True)\n",
-    "cf1b = CfRadial('knmi_odim_as_cfradial.nc', georef=True)"
+    "cf1a = OdimH5(h5_tempfile, standard='cf', georef=True)\n",
+    "cf1b = CfRadial(nc_tempfile, georef=True)"
    ]
   },
   {
@@ -528,8 +531,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cf2.to_cfradial2('timrex_cfradial2.nc')\n",
-    "cf2.to_odim('timrex_cfradial_as_odim.h5')"
+    "h5_tempfile = tempfile.NamedTemporaryFile(suffix=\".h5\").name\n",
+    "nc_tempfile = tempfile.NamedTemporaryFile(suffix=\".nc\").name\n",
+    "cf2.to_cfradial2(nc_tempfile)\n",
+    "cf2.to_odim(h5_tempfile)"
    ]
   },
   {
@@ -554,8 +559,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cf2a = CfRadial('timrex_cfradial2.nc')\n",
-    "cf2b = OdimH5('timrex_cfradial_as_odim.h5', standard='cf')"
+    "cf2a = CfRadial(nc_tempfile)\n",
+    "cf2b = OdimH5(h5_tempfile, standard='cf')"
    ]
   },
   {
@@ -614,7 +619,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/notebooks/zonalstats/wradlib_zonal_stats_polar_grid.ipynb
+++ b/notebooks/zonalstats/wradlib_zonal_stats_polar_grid.ipynb
@@ -541,7 +541,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.9"
+   "version": "3.10.0"
   },
   "toc": {
    "colors": {

--- a/notebooks/zonalstats/wradlib_zonal_stats_rectangular_grid.ipynb
+++ b/notebooks/zonalstats/wradlib_zonal_stats_rectangular_grid.ipynb
@@ -124,7 +124,8 @@
     "# Read and prepare the actual data (RADOLAN)\n",
     "f = wrl.util.get_wradlib_data_file(\n",
     "    'radolan/misc/raa01-sf_10000-1406100050-dwd---bin.gz')\n",
-    "ds = wrl.io.open_radolan_dataset(f)"
+    "ds = wrl.io.open_radolan_dataset(f)\n",
+    "display(ds)"
    ]
   },
   {
@@ -134,7 +135,10 @@
    "outputs": [],
    "source": [
     "# create radolan projection osr object\n",
-    "proj_stereo = wrl.georef.create_osr(\"dwd-radolan\")\n",
+    "if ds.attrs[\"formatversion\"] >= 5:\n",
+    "    proj_stereo = wrl.georef.create_osr(\"dwd-radolan-wgs84\")\n",
+    "else:\n",
+    "    proj_stereo = wrl.georef.create_osr(\"dwd-radolan-sphere\")\n",
     "\n",
     "# create UTM Zone 32 projection osr object\n",
     "proj_utm = osr.SpatialReference()\n",
@@ -151,7 +155,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(proj_gk2)"
+    "gridres = ds.x.diff(\"x\")[0].values\n",
+    "gridres"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(proj_stereo)"
    ]
   },
   {
@@ -236,7 +250,7 @@
     "\n",
     "# Get RADOLAN center grid points for each grid cell\n",
     "# (MUST BE DONE IN NATIVE RADOLAN COORDINATES)\n",
-    "grid_x, grid_y = np.meshgrid(ds_clip.x + 0.5, ds_clip.y + 0.5)\n",
+    "grid_x, grid_y = np.meshgrid(ds_clip.x, ds_clip.y)\n",
     "grdpoints = np.dstack([grid_x, grid_y]).reshape(-1, 2)\n",
     "\n",
     "src = wrl.io.VectorSource(grdpoints, srs=proj_utm, name=\"src\", projection_source=proj_stereo)\n",
@@ -367,10 +381,10 @@
     "\n",
     "# Create vertices for each grid cell\n",
     "# (MUST BE DONE IN NATIVE RADOLAN COORDINATES)\n",
-    "grid_x, grid_y = np.meshgrid(ds_clip.x + 0.5, ds_clip.y + 0.5)\n",
+    "grid_x, grid_y = np.meshgrid(ds_clip.x, ds_clip.y)\n",
     "grdverts = wrl.zonalstats.grid_centers_to_vertices(grid_x,\n",
     "                                                   grid_y, \n",
-    "                                                   1., 1.)\n",
+    "                                                   gridres, gridres)\n",
     "# And reproject to Cartesian reference system (here: UTM Zone 32)\n",
     "src = wrl.io.VectorSource(grdverts, srs=proj_utm, name=\"src\", projection_source=proj_stereo)\n",
     "trg = wrl.io.VectorSource(shpfile, srs=proj_utm, name=\"trg\", projection_source=proj_gk2)\n",
@@ -452,6 +466,9 @@
     "isecs1 = obj3.zdata.dst.get_data_by_att(attr=\"trg_index\", value=[i], mode=\"geo\")\n",
     "isecs1.plot(column=\"src_index\", ax=ax, cmap=pl.cm.plasma, alpha=0.5)\n",
     "\n",
+    "# scatter center points\n",
+    "ds_clip.plot.scatter(x=\"xc\", y=\"yc\")\n",
+    "\n",
     "cat = trg.get_data_by_idx([i])[0]\n",
     "bbox = wrl.zonalstats.get_bbox(cat[..., 0], cat[..., 1])\n",
     "pl.xlim(bbox[\"left\"] - 2000, bbox[\"right\"] + 2000)\n",
@@ -492,7 +509,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.9"
+   "version": "3.10.0"
   },
   "toc": {
    "colors": {

--- a/notebooks/zonalstats/wradlib_zonalstats_example.ipynb
+++ b/notebooks/zonalstats/wradlib_zonalstats_example.ipynb
@@ -140,8 +140,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "gridres = ds.x.diff(\"x\")[0].values\n",
+    "gridres"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# create radolan projection osr object\n",
-    "proj_stereo = wrl.georef.create_osr(\"dwd-radolan\")\n",
+    "if ds.attrs[\"formatversion\"] >= 5:\n",
+    "    proj_stereo = wrl.georef.create_osr(\"dwd-radolan-wgs84\")\n",
+    "else:\n",
+    "    proj_stereo = wrl.georef.create_osr(\"dwd-radolan-sphere\")\n",
     "\n",
     "# create UTM Zone 32 projection osr object\n",
     "proj_utm = osr.SpatialReference()\n",
@@ -236,7 +249,7 @@
     "\n",
     "# Get RADOLAN center grid points for each grid cell\n",
     "# (MUST BE DONE IN NATIVE RADOLAN COORDINATES)\n",
-    "grid_x, grid_y = np.meshgrid(ds_clip.x + 0.5, ds_clip.y + 0.5)\n",
+    "grid_x, grid_y = np.meshgrid(ds_clip.x, ds_clip.y)\n",
     "grdpoints = np.dstack([grid_x, grid_y]).reshape(-1, 2)\n",
     "\n",
     "src = wrl.io.VectorSource(grdpoints, srs=proj_utm, name=\"src\", projection_source=proj_stereo)\n",
@@ -358,10 +371,10 @@
     "\n",
     "# Create vertices for each grid cell\n",
     "# (MUST BE DONE IN NATIVE RADOLAN COORDINATES)\n",
-    "grid_x, grid_y = np.meshgrid(ds_clip.x + 0.5, ds_clip.y + 0.5)\n",
+    "grid_x, grid_y = np.meshgrid(ds_clip.x, ds_clip.y)\n",
     "grdverts = wrl.zonalstats.grid_centers_to_vertices(grid_x,\n",
     "                                                   grid_y, \n",
-    "                                                   1., 1.)\n",
+    "                                                   gridres, gridres)\n",
     "# And reproject to Cartesian reference system (here: UTM Zone 32)\n",
     "src = wrl.io.VectorSource(grdverts, srs=proj_utm, name=\"src\", projection_source=proj_stereo)\n",
     "trg = wrl.io.VectorSource(shpfile, srs=proj_utm, name=\"trg\", projection_source=proj_gk2)\n",
@@ -427,6 +440,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "ds_clip"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# Illustrate results for an example catchment i\n",
     "i = 6  # try e.g. 5, 2\n",
     "fig = pl.figure(figsize=(10,8))\n",
@@ -445,12 +467,17 @@
     "isecs1 = obj3.zdata.dst.get_data_by_att(attr=\"trg_index\", value=[i], mode=\"geo\")\n",
     "isecs1.plot(column=\"src_index\", ax=ax, cmap=pl.cm.plasma, alpha=0.5)\n",
     "\n",
+    "# scatter center points\n",
+    "ds_clip.plot.scatter(x=\"xc\", y=\"yc\", s=10)\n",
+    "\n",
     "cat = trg.get_data_by_idx([i])[0]\n",
     "bbox = wrl.zonalstats.get_bbox(cat[..., 0], cat[..., 1])\n",
     "pl.xlim(bbox[\"left\"] - 2000, bbox[\"right\"] + 2000)\n",
     "pl.ylim(bbox[\"bottom\"] - 2000, bbox[\"top\"] + 2000)\n",
     "pl.legend()\n",
-    "pl.title(\"Catchment #%d: Polygons considered for stats\" % i)"
+    "pl.title(\"Catchment #%d: Polygons considered for stats\" % i)\n",
+    "#pl.gca().set_xlim(402000, 404000)\n",
+    "#pl.gca().set_ylim(5642000, 5644000)"
    ]
   },
   {
@@ -487,9 +514,9 @@
    "source": [
     "def create_center_coords(ds, proj=None):\n",
     "    # create polar grid centroids in GK2\n",
-    "    center = wrl.georef.spherical_to_centroids(ds.range.values, \n",
+    "    center = wrl.georef.spherical_to_centroids(ds.data.r, \n",
     "                                               ds.azimuth.values, \n",
-    "                                               0.5, \n",
+    "                                               ds.elevation.values, \n",
     "                                               (ds.longitude.values, ds.latitude.values, ds.altitude.values),\n",
     "                                               proj=proj)\n",
     "    ds = ds.assign_coords({\"xc\": ([\"azimuth\", \"range\"], center[..., 0]),\n",
@@ -512,11 +539,19 @@
     "                       \"longitude\": ds.data.Longitude, \n",
     "                       \"altitude\": 99.5,\n",
     "                       \"azimuth\": ds.data.az,\n",
-    "                       \"range\": ds.data.r,\n",
+    "                       # bin centers\n",
+    "                       \"range\": ds.data.r - np.median(np.diff(ds.data.r)) / 2.,\n",
     "                       \"sweep_mode\": \"azimuth_surveillance\",\n",
     "                       \"elevation\": 0.5}\n",
-    "                     )\n",
-    "\n",
+    "                     )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "ds = ds.pipe(wrl.georef.georeference_dataset, proj=proj_utm)\n",
     "ds = ds.pipe(create_center_coords, proj=proj_utm)\n",
     "display(ds)"
@@ -699,7 +734,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "radar_utm = wrl.georef.spherical_to_polyvert(ds.range.values, \n",
+    "radar_utm = wrl.georef.spherical_to_polyvert(ds.range.values + np.median(np.diff(ds.range.values)) / 2., \n",
     "                                 ds.azimuth.values, \n",
     "                                 0.5, \n",
     "                                 (ds.longitude.values, ds.latitude.values, ds.altitude.values),\n",
@@ -708,7 +743,7 @@
     "ds = ds.assign_coords({\"xp\": ([\"azimuth\", \"range\", \"verts\"], radar_utm[..., 0]),\n",
     "                       \"yp\": ([\"azimuth\", \"range\", \"verts\"], radar_utm[..., 1]),\n",
     "                       \"zp\": ([\"azimuth\", \"range\", \"verts\"], radar_utm[..., 2])})\n",
-    "display(ds)\n",
+    "\n",
     "trg = wrl.io.VectorSource(shpfile, srs=proj_utm, name=\"trg\", projection_source=proj_gk2)\n",
     "bbox = trg.extent\n",
     "\n",
@@ -779,11 +814,11 @@
     "print(\n",
     "\"\\tCompute stats using object: %f seconds\" % (t3 - t2).total_seconds())\n",
     "\n",
-    "obj3.zdata.trg.dump_raster('test_zonal_hdr.nc', 'netCDF', 'mean',\n",
+    "obj4.zdata.trg.dump_raster('test_zonal_hdr.nc', 'netCDF', 'mean',\n",
     "                           pixel_size=100.)\n",
     "\n",
-    "obj3.zdata.trg.dump_vector('test_zonal_shp')\n",
-    "obj3.zdata.trg.dump_vector('test_zonal_json.geojson', 'GeoJSON')\n",
+    "obj4.zdata.trg.dump_vector('test_zonal_shp')\n",
+    "obj4.zdata.trg.dump_vector('test_zonal_json.geojson', 'GeoJSON')\n",
     "\n",
     "# Target polygon patches\n",
     "trg_patches = [patches.Polygon(item, True) for item in obj3.zdata.trg.data]"
@@ -843,12 +878,17 @@
     "isecs1 = obj3.zdata.dst.get_data_by_att(attr=\"trg_index\", value=[i], mode=\"geo\")\n",
     "isecs1.plot(column=\"src_index\", ax=ax, cmap=pl.cm.plasma, alpha=0.5)\n",
     "\n",
+    "# scatter center points\n",
+    "ds_clip.plot.scatter(x=\"xc\", y=\"yc\", s=10)\n",
+    "\n",
     "cat = trg.get_data_by_idx([i])[0]\n",
     "bbox = wrl.zonalstats.get_bbox(cat[..., 0], cat[..., 1])\n",
     "pl.xlim(bbox[\"left\"] - 2000, bbox[\"right\"] + 2000)\n",
     "pl.ylim(bbox[\"bottom\"] - 2000, bbox[\"top\"] + 2000)\n",
     "pl.legend()\n",
-    "pl.title(\"Catchment #%d: Polygons considered for stats\" % i)"
+    "pl.title(\"Catchment #%d: Polygons considered for stats\" % i)\n",
+    "pl.gca().set_xlim(402000, 404000)\n",
+    "pl.gca().set_ylim(5654000, 5656000)\n"
    ]
   },
   {
@@ -883,7 +923,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.9"
+   "version": "3.10.0"
   },
   "toc": {
    "colors": {

--- a/notebooks/zonalstats/wradlib_zonalstats_quickstart.ipynb
+++ b/notebooks/zonalstats/wradlib_zonalstats_quickstart.ipynb
@@ -126,6 +126,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gridres = ds.x.diff(\"x\")[0].values\n",
+    "gridres"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "slideshow": {
      "slide_type": "fragment"
@@ -135,7 +145,11 @@
    "source": [
     "# This is the native RADOLAN projection\n",
     "# (polar stereographic projection)\n",
-    "proj_stereo = wrl.georef.create_osr(\"dwd-radolan\")\n",
+    "# create radolan projection osr object\n",
+    "if ds.attrs[\"formatversion\"] >= 5:\n",
+    "    proj_stereo = wrl.georef.create_osr(\"dwd-radolan-wgs84\")\n",
+    "else:\n",
+    "    proj_stereo = wrl.georef.create_osr(\"dwd-radolan-sphere\")\n",
     "\n",
     "# This is our target projection (UTM Zone 32)\n",
     "proj_utm = osr.SpatialReference()\n",
@@ -347,10 +361,11 @@
    "source": [
     "# Create vertices for each grid cell\n",
     "# (MUST BE DONE IN NATIVE RADOLAN COORDINATES)\n",
-    "grid_x, grid_y = np.meshgrid(ds_clip.x + 0.5, ds_clip.y + 0.5)\n",
+    "grid_x, grid_y = np.meshgrid(ds_clip.x, ds_clip.y)\n",
     "grdverts = wrl.zonalstats.grid_centers_to_vertices(grid_x,\n",
     "                                                   grid_y, \n",
-    "                                                   1., 1.)"
+    "                                                   gridres, \n",
+    "                                                   gridres)"
    ]
   },
   {
@@ -579,13 +594,6 @@
     "pl.ylim(bbox[2] - 5000, bbox[3] + 5000)\n",
     "pl.grid()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -600,7 +608,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.9"
+   "version": "3.10.0"
   },
   "livereveal": {
    "scroll": true


### PR DESCRIPTION
DWD has recently updated some of their products to use wgs84 ellipsoid instead of sphere as earth model.

This PR adapts to recent changes in wradlib https://github.com/wradlib/wradlib/pull/568.