### PR TITLE
MNT: disable triggering of wradlib-docs readthedocs processing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -187,4 +187,5 @@ jobs:
     steps:
     - name: trigger readthedocs
       run: |
-        curl -X POST -d "token=$RTD_TOKEN" "$RTD_URL"
+        echo "not triggering"
+        # curl -X POST -d "token=$RTD_TOKEN" "$RTD_URL"


### PR DESCRIPTION
 until new wradlib docs layout is established